### PR TITLE
chore: upgrade LTI 1.3 libraries to versions that support PHP 8.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1710,16 +1710,16 @@
         },
         {
             "name": "oat-sa/lib-lti1p3-core",
-            "version": "7.2.2",
+            "version": "7.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/lib-lti1p3-core.git",
-                "reference": "9ab7abc1e86987d457b3c7f5143173c9d40a0dd7"
+                "reference": "84d596855889970278d1c9a0ff1a6246db1de1ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-core/zipball/9ab7abc1e86987d457b3c7f5143173c9d40a0dd7",
-                "reference": "9ab7abc1e86987d457b3c7f5143173c9d40a0dd7",
+                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-core/zipball/84d596855889970278d1c9a0ff1a6246db1de1ab",
+                "reference": "84d596855889970278d1c9a0ff1a6246db1de1ab",
                 "shasum": ""
             },
             "require": {
@@ -1727,7 +1727,7 @@
                 "ext-json": "*",
                 "ext-openssl": "*",
                 "guzzlehttp/guzzle": "^7.8",
-                "lcobucci/jwt": "^4.3",
+                "lcobucci/jwt": "^4.3 || ^5.0",
                 "league/oauth2-server": "^8.5 || ^9.2",
                 "nesbot/carbon": "^2.72 || ^3.0",
                 "nyholm/psr7": "^1.8",
@@ -1759,9 +1759,9 @@
             "description": "OAT LTI 1.3 Core Library",
             "support": {
                 "issues": "https://github.com/oat-sa/lib-lti1p3-core/issues",
-                "source": "https://github.com/oat-sa/lib-lti1p3-core/tree/7.2.2"
+                "source": "https://github.com/oat-sa/lib-lti1p3-core/tree/7.2.3"
             },
-            "time": "2025-06-24T09:03:17+00:00"
+            "time": "2025-07-18T12:30:08+00:00"
         },
         {
             "name": "oat-sa/lib-lti1p3-deep-linking",
@@ -1852,23 +1852,23 @@
         },
         {
             "name": "oat-sa/lib-lti1p3-proctoring",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/lib-lti1p3-proctoring.git",
-                "reference": "c18db5ae93fc66a51599e3b5b3e2fbb90923d212"
+                "reference": "abd1590f1ba16e3c4627aef451e42cff4e05da12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-proctoring/zipball/c18db5ae93fc66a51599e3b5b3e2fbb90923d212",
-                "reference": "c18db5ae93fc66a51599e3b5b3e2fbb90923d212",
+                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-proctoring/zipball/abd1590f1ba16e3c4627aef451e42cff4e05da12",
+                "reference": "abd1590f1ba16e3c4627aef451e42cff4e05da12",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "nesbot/carbon": "^2.72 || ^3.0",
                 "nyholm/psr7": "^1.8",
-                "oat-sa/lib-lti1p3-core": "7.2.2",
+                "oat-sa/lib-lti1p3-core": "^7.0",
                 "php": ">=8.0.0",
                 "psr/http-message": "^1.1 || ^2.0"
             },
@@ -1892,9 +1892,9 @@
             "description": "OAT LTI 1.3 Proctoring Library",
             "support": {
                 "issues": "https://github.com/oat-sa/lib-lti1p3-proctoring/issues",
-                "source": "https://github.com/oat-sa/lib-lti1p3-proctoring/tree/1.0.3"
+                "source": "https://github.com/oat-sa/lib-lti1p3-proctoring/tree/1.0.4"
             },
-            "time": "2025-06-24T09:46:00+00:00"
+            "time": "2025-07-18T15:54:59+00:00"
         },
         {
             "name": "oat-sa/lib-lti1p3-submission-review",


### PR DESCRIPTION
This is a follow up to #171